### PR TITLE
locked orientation to portrait mode only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientation"
             android:exported="true"
             android:theme="@style/Theme.ZaDumitefrontend">
             <intent-filter>


### PR DESCRIPTION
Lock screen orientation to portrait mode for better UX consistency
- prevents unwanted UI breakage or layout shifts on screen rotation

If plans to support tablets or Chrome OS occur in the future, I may need to revisit this decision to allow dynamic orientation based on device type.