### PR TITLE
Implement automatic logout on token refresh failure

### DIFF
--- a/app/src/main/java/com/example/zadumite_frontend/data/authenticator/AuthAuthenticator.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/data/authenticator/AuthAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.example.zadumite_frontend.data.authenticator
 
+import com.example.zadumite_frontend.data.model.session.SessionManager
 import com.example.zadumite_frontend.data.model.token.JwtTokenManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
@@ -7,9 +8,11 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 
+//intercepts failed requests due to expired JWT
 class AuthAuthenticator(
     private val tokenManager: JwtTokenManager,
-    private val refreshTokenHandler: RefreshTokenHandler
+    private val refreshTokenHandler: RefreshTokenHandler,
+    private val sessionManager: SessionManager
 ) : Authenticator {
     override fun authenticate(route: Route?, response: Response): Request? {
         return runBlocking {
@@ -24,6 +27,7 @@ class AuthAuthenticator(
                     .header("Authorization", "Bearer ${newTokenResponse.accessToken}")
                     .build()
             } else {
+                sessionManager.logout()
                 null
             }
         }

--- a/app/src/main/java/com/example/zadumite_frontend/data/model/session/DefaultSessionManager.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/data/model/session/DefaultSessionManager.kt
@@ -1,0 +1,12 @@
+package com.example.zadumite_frontend.data.model.session
+import com.example.zadumite_frontend.data.model.token.JwtTokenManager
+
+class DefaultSessionManager(
+    private val tokenManager: JwtTokenManager,
+    private val logoutNotifier: LogoutNotifier
+) : SessionManager {
+    override suspend fun logout() {
+        tokenManager.clearAllTokens()
+        logoutNotifier.notifyLogout()
+    }
+}

--- a/app/src/main/java/com/example/zadumite_frontend/data/model/session/LogoutNotifier.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/data/model/session/LogoutNotifier.kt
@@ -1,0 +1,13 @@
+package com.example.zadumite_frontend.data.model.session
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+class LogoutNotifier {
+    private val _logoutFlow = MutableSharedFlow<Unit>(replay = 0)
+    val logoutFlow: SharedFlow<Unit> = _logoutFlow
+
+    suspend fun notifyLogout() {
+        _logoutFlow.emit(Unit)
+    }
+}

--- a/app/src/main/java/com/example/zadumite_frontend/data/model/session/SessionManager.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/data/model/session/SessionManager.kt
@@ -1,0 +1,5 @@
+package com.example.zadumite_frontend.data.model.session
+
+interface SessionManager {
+    suspend fun logout()
+}

--- a/app/src/main/java/com/example/zadumite_frontend/di/AppModule.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/di/AppModule.kt
@@ -7,5 +7,6 @@ val appModule = listOf(
     authenticatorModule,
     repositoryModule,
     useCaseModule,
-    viewModelModule
+    viewModelModule,
+    sessionModule
 )

--- a/app/src/main/java/com/example/zadumite_frontend/di/SessionModule.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/di/SessionModule.kt
@@ -1,0 +1,11 @@
+package com.example.zadumite_frontend.di
+
+import com.example.zadumite_frontend.data.model.session.DefaultSessionManager
+import com.example.zadumite_frontend.data.model.session.LogoutNotifier
+import com.example.zadumite_frontend.data.model.session.SessionManager
+import org.koin.dsl.module
+
+val sessionModule = module {
+    single { LogoutNotifier() }
+    single<SessionManager> { DefaultSessionManager(get(), get()) }
+}

--- a/app/src/main/java/com/example/zadumite_frontend/navigation/NavigationStack.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/navigation/NavigationStack.kt
@@ -1,8 +1,10 @@
 package com.example.zadumite_frontend.navigation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.zadumite_frontend.data.model.session.LogoutNotifier
 import com.example.zadumite_frontend.ui.signup.SignUpScreen
 import com.example.zadumite_frontend.ui.start_screen.StartScreen
 import com.example.zadumite_frontend.ui.add_word.AddWordScreen
@@ -11,10 +13,21 @@ import com.example.zadumite_frontend.ui.profile.ProfileScreen
 import com.example.zadumite_frontend.ui.scaffold.ZaDumiteScaffold
 import com.example.zadumite_frontend.ui.user_words.UserWordsScreen
 import com.example.zadumite_frontend.ui.word.WordOfTheWeekScreen
+import org.koin.compose.getKoin
 
 @Composable
 fun NavigationStack() {
     val navController = rememberNavController()
+    val logoutNotifier: LogoutNotifier = getKoin().get()
+
+    LaunchedEffect(Unit) {
+        logoutNotifier.logoutFlow.collect {
+            navController.navigate(Screen.Start.route) {
+                popUpTo(0) { inclusive = true }
+            }
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = Screen.Start.route
@@ -27,7 +40,7 @@ fun NavigationStack() {
         }
         composable(route = Screen.SignUp.route) {
             SignUpScreen(
-                onNavigateBack = { navController.popBackStack() },
+                onNavigateBack = { navController.navigate(Screen.Start.route) },
                 onNavigateToWordScreen = { navController.navigate(Screen.Word.route) }
             )
         }


### PR DESCRIPTION
This PR adds a logout mechanism that automatically logs the user out and redirects to the Start screen if token refresh fails (e.g., due to an expired or invalid refresh token).
- `SessionManager` centralizes logout behavior
- `LogoutNotifier` uses a SharedFlow to emit logout events (SharedFlow lets the app react to one-time events like logout, navigation, or showing a snackbar from anywhere)
- `AuthAuthenticator` triggers `logout()` when token refresh fails
- `NavigationStack` observes logout events and navigates to `Screen.Start` while clearing the back stack
