### PR TITLE
 display user score in profile screen

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,7 +3,20 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State />
+        <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="SERIAL_NUMBER" />
+                  <value value="adb-RFCT518BXVB-5VhXVW._adb-tls-connect._tcp" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2025-05-24T10:56:50.308369800Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,8 +25,6 @@
             android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientation"
-            android:screenOrientation="portrait"
-            tools:ignore="LockedOrientation"
             android:exported="true"
             android:theme="@style/Theme.ZaDumitefrontend">
             <intent-filter>

--- a/app/src/main/java/com/example/zadumite_frontend/di/ViewModelModule.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/di/ViewModelModule.kt
@@ -17,6 +17,6 @@ val viewModelModule = module {
     viewModel { UserWordsViewModel(get()) }
     viewModel { AddWordViewModel(get()) }
     viewModel { NetworkViewModel(get()) }
-    viewModel { ProfileViewModel(get(), get()) }
+    viewModel { ProfileViewModel(get(), get(), get()) }
     viewModel { DailyQuestionViewModel(get(), get(), get()) }
 }

--- a/app/src/main/java/com/example/zadumite_frontend/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/ui/profile/ProfileScreen.kt
@@ -48,6 +48,7 @@ fun ProfileScreen(
     val errorMessage by viewModel.errorMessage
     val networkStatus by networkViewModel.networkStatus.collectAsState()
     val isNetworkAvailable = networkStatus == ConnectivityObserver.Status.Available
+    val userScore by viewModel.userScore
     var showDialog by remember { mutableStateOf(false) }
 
 
@@ -122,6 +123,15 @@ fun ProfileScreen(
                         label = stringResource(R.string.password),
                         isReadOnly = true
                     )
+
+                    if (userScore != null) {
+                        CustomOutlinedTextField(
+                            value = userScore.toString(),
+                            onValueChange = {},
+                            label = stringResource(R.string.total_score),
+                            isReadOnly = true
+                        )
+                    }
 
                     CustomButton(
                         text = stringResource(R.string.logout),

--- a/app/src/main/java/com/example/zadumite_frontend/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/ui/profile/ProfileViewModel.kt
@@ -2,8 +2,6 @@ package com.example.zadumite_frontend.ui.profile
 
 import android.content.Context
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.zadumite_frontend.R
@@ -12,16 +10,21 @@ import com.example.zadumite_frontend.domain.GetUserUseCase
 import com.example.zadumite_frontend.domain.LogoutUseCase
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.State
+import com.example.zadumite_frontend.domain.GetUserScoreUseCase
 
 
 class ProfileViewModel(
     private val getUserUseCase: GetUserUseCase,
-    private val logoutUseCase: LogoutUseCase
+    private val logoutUseCase: LogoutUseCase,
+    private val getUserScoreUseCase: GetUserScoreUseCase
 ) : ViewModel() {
     private val _profileState = mutableStateOf<User?>(null)
     val profileState: State<User?> = _profileState
 
     private val _logoutState = mutableStateOf(false)
+
+    private val _userScore = mutableStateOf<Int?>(null)
+    val userScore: State<Int?> = _userScore
 
     private val _isLoading = mutableStateOf(false)
     val isLoading: State<Boolean> = _isLoading
@@ -35,6 +38,15 @@ class ProfileViewModel(
             try {
                 val user = getUserUseCase()
                 _profileState.value = user
+
+                val scoreResult = getUserScoreUseCase()
+                scoreResult
+                    .onSuccess { score ->
+                        _userScore.value = score
+                    }
+                    .onFailure {
+                        _errorMessage.value = context.getString(R.string.failed_fetching_score)
+                    }
             } catch (e: Exception) {
                 _errorMessage.value = context.getString(R.string.failed_fetching_user)
             } finally {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,6 @@
     <string name="error_access_token_missing">Access token is missing.</string>
     <string name="error_unauthorized_admin_only">Unauthorized: Only admins can add words.</string>
     <string name="error_add_word_failed">Failed to add word: %1$s</string>
+    <string name="total_score">Брой точки</string>
+    <string name="failed_fetching_score">Failed to fetch user score</string>
 </resources>


### PR DESCRIPTION
Displays the logged-in user's total score on the profile screen using GetUserScoreUseCase.
- integrated GetUserScoreUseCase into ProfileViewModel
- fetched user score alongside profile details
- displayed the score in a read-only text field in the UI
- added string resource for total score and error handling if fetching fails