### PR TITLE
Refactor notification scheduling and extract strings for localization

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,20 +3,7 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State>
-          <runningDeviceTargetSelectedWithDropDown>
-            <Target>
-              <type value="RUNNING_DEVICE_TARGET" />
-              <deviceKey>
-                <Key>
-                  <type value="SERIAL_NUMBER" />
-                  <value value="adb-RFCT518BXVB-5VhXVW._adb-tls-connect._tcp" />
-                </Key>
-              </deviceKey>
-            </Target>
-          </runningDeviceTargetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2025-05-24T10:56:50.308369800Z" />
-        </State>
+        <State />
       </entry>
     </value>
   </component>

--- a/app/src/main/java/com/example/zadumite_frontend/MainActivity.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/MainActivity.kt
@@ -13,6 +13,7 @@ import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import com.example.zadumite_frontend.utils.notifications.scheduleWeeklyNotification
 
 class MainActivity : ComponentActivity() {
 
@@ -20,6 +21,7 @@ class MainActivity : ComponentActivity() {
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
                 Toast.makeText(this, "Notification permission granted", Toast.LENGTH_SHORT).show()
+                scheduleWeeklyNotification(applicationContext)
             } else {
                 Toast.makeText(this, "Notification permission denied", Toast.LENGTH_SHORT).show()
             }
@@ -28,7 +30,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        requestNotificationPermission()
         createNotificationChannel()
 
         setContent {
@@ -37,17 +38,15 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val name = "Daily Question"
-            val descriptionText = "Daily popup for new questions"
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            val channel = NotificationChannel("daily_question_channel", name, importance).apply {
-                description = descriptionText
-            }
-            val notificationManager =
-                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
+        val name = "Daily Question"
+        val descriptionText = "Daily popup for new questions"
+        val importance = NotificationManager.IMPORTANCE_DEFAULT
+        val channel = NotificationChannel("daily_question_channel", name, importance).apply {
+            description = descriptionText
         }
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
     }
 
     fun requestNotificationPermission() {

--- a/app/src/main/java/com/example/zadumite_frontend/di/providers/provideRetrofit.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/di/providers/provideRetrofit.kt
@@ -4,7 +4,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-private const val BASE_URL = "http://192.168.0.8:3000/"
+private const val BASE_URL = "http://192.168.0.3:3000/"
 //private const val BASE_URL = "http://10.0.2.2:3000/" // for emulator testing
 
 fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationHandler.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationHandler.kt
@@ -1,5 +1,6 @@
 package com.example.zadumite_frontend.utils.notifications
 
+import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import androidx.core.app.NotificationCompat
@@ -8,14 +9,27 @@ import kotlin.random.Random
 
 class NotificationHandler(private val context: Context) {
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
-    private val notificationChannelID = "new_word"
+    private val notificationChannelID = context.getString(R.string.notification_channel_id)
 
+    init {
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val name = context.getString(R.string.notification_channel_name)
+        val descriptionText = context.getString(R.string.notification_channel_description)
+        val importance = NotificationManager.IMPORTANCE_HIGH
+        val channel = NotificationChannel(notificationChannelID, name, importance).apply {
+            description = descriptionText
+        }
+        notificationManager.createNotificationChannel(channel)
+    }
     fun showWordOfWeekNotification() {
         val notification = NotificationCompat.Builder(context, notificationChannelID)
-            .setContentTitle("Дума на седмицата")
-            .setContentText("Узнай думата на седмицата!")
+            .setContentTitle(context.getString(R.string.notification_title))
+            .setContentText(context.getString(R.string.notification_text))
             .setSmallIcon(R.drawable.notification)
-            .setPriority(NotificationManager.IMPORTANCE_HIGH)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .build()
 

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationWorker.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationWorker.kt
@@ -1,32 +1,18 @@
 package com.example.zadumite_frontend.utils.notifications
 
 import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import android.util.Log
 import androidx.work.CoroutineWorker
-import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.example.zadumite_frontend.data.model.datastore.JwtTokenDataStore
-import com.example.zadumite_frontend.data.model.token.JwtTokenManager
-import java.util.prefs.Preferences
 
 class NotificationWorker(
     context: Context,
     workerParams: WorkerParameters,
-    private val jwtTokenManager: JwtTokenManager
 ) :  CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result {
-        val context = applicationContext
-
-        val accessToken = jwtTokenManager.getAccessJwt()
-
-        if (accessToken.isNullOrEmpty()) {
-            return Result.success()
-        }
-
-        val notificationHandler = NotificationHandler(context)
+        Log.d("NotificationWorker", "Showing notification")
+        val notificationHandler = NotificationHandler(applicationContext)
         notificationHandler.showWordOfWeekNotification()
-
         return Result.success()
     }
 }

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleWeeklyNotification.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleWeeklyNotification.kt
@@ -3,37 +3,61 @@ package com.example.zadumite_frontend.utils.notifications
 import android.content.Context
 import androidx.work.WorkManager
 import androidx.work.Data
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
 import java.util.concurrent.TimeUnit
 
 import androidx.work.PeriodicWorkRequestBuilder
 import java.util.Calendar
 
 fun scheduleWeeklyNotification(context: Context) {
-    val calendar = Calendar.getInstance().apply {
-        set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
-        set(Calendar.HOUR_OF_DAY, 9)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-    }
-
-    val currentTime = System.currentTimeMillis()
-    val notificationTime = calendar.timeInMillis
-
-    if (notificationTime <= currentTime) {
-        calendar.add(Calendar.WEEK_OF_YEAR, 1)
-    }
-
-    val initialDelay = calendar.timeInMillis - currentTime
+    val testMode = true
 
     val inputData = Data.Builder()
         .putString("title", "Дума на седмицата")
         .putString("message", "Узнай думата на седмицата!")
         .build()
 
-    val weeklyWorkRequest = PeriodicWorkRequestBuilder<NotificationWorker>(7, TimeUnit.DAYS)
-        .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
-        .setInputData(inputData)
-        .build()
+    if (testMode) {
+        val testWorkRequest = OneTimeWorkRequestBuilder<NotificationWorker>()
+            .setInitialDelay(30, TimeUnit.SECONDS)
+            .setInputData(inputData)
+            .build()
 
-    WorkManager.getInstance(context).enqueue(weeklyWorkRequest)
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            "TestNotification",
+            ExistingWorkPolicy.REPLACE,
+            testWorkRequest
+        )
+    } else {
+        val calendar = Calendar.getInstance().apply {
+            timeInMillis = System.currentTimeMillis()
+            set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+            set(Calendar.HOUR_OF_DAY, 9)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        val currentTime = System.currentTimeMillis()
+        var notificationTime = calendar.timeInMillis
+        if (notificationTime <= currentTime) {
+            calendar.add(Calendar.WEEK_OF_YEAR, 1)
+            notificationTime = calendar.timeInMillis
+        }
+
+        val initialDelay = notificationTime - currentTime
+
+        val weeklyWorkRequest = PeriodicWorkRequestBuilder<NotificationWorker>(7, TimeUnit.DAYS)
+            .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
+            .setInputData(inputData)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            "WeeklyNotification",
+            ExistingPeriodicWorkPolicy.UPDATE,
+            weeklyWorkRequest
+        )
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ZaDumite-frontend</string>
+    <string name="app_name">За думите</string>
     <string name="app_title">За думите</string>
     <string name="login">Влизане</string>
     <string name="signup">Регистрация</string>
@@ -71,4 +71,9 @@
     <string name="error_add_word_failed">Failed to add word: %1$s</string>
     <string name="total_score">Брой точки</string>
     <string name="failed_fetching_score">Failed to fetch user score</string>
+    <string name="notification_title">Дума на седмицата</string>
+    <string name="notification_text">Узнай думата на седмицата!</string>
+    <string name="notification_channel_id">new_word</string>
+    <string name="notification_channel_name">Дума на седмицата</string>
+    <string name="notification_channel_description">Известия за думата на седмицата</string>
 </resources>


### PR DESCRIPTION
This PR simplifies and improves the notification system by refactoring how and when notifications are scheduled, and by externalizing all hardcoded strings to `strings.xml`.
Replaced old token-checking logic inside `NotificationWorker` with a cleaner flow:
  - notifications are now scheduled only after the user successfully logs in.
  - this ensures only logged-in users receive notifications without needing to check token state in background workers.
Removed access token dependency from `NotificationWorker`.
Moved hardcoded strings related to notifications into `strings.xml`:
  - notification title and message
  - notification channel ID, name, and description