### PR TITLE
Add daily question notification at 10 a.m. using WorkManager

### DIFF
--- a/app/src/main/java/com/example/zadumite_frontend/MainActivity.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/MainActivity.kt
@@ -13,6 +13,7 @@ import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import com.example.zadumite_frontend.utils.notifications.scheduleDailyNotification
 import com.example.zadumite_frontend.utils.notifications.scheduleWeeklyNotification
 
 class MainActivity : ComponentActivity() {
@@ -22,6 +23,7 @@ class MainActivity : ComponentActivity() {
             if (isGranted) {
                 Toast.makeText(this, "Notification permission granted", Toast.LENGTH_SHORT).show()
                 scheduleWeeklyNotification(applicationContext)
+                scheduleDailyNotification(applicationContext)
             } else {
                 Toast.makeText(this, "Notification permission denied", Toast.LENGTH_SHORT).show()
             }
@@ -55,11 +57,18 @@ class MainActivity : ComponentActivity() {
                 == PackageManager.PERMISSION_GRANTED
             ) {
                 Toast.makeText(this, "Notification permission already granted", Toast.LENGTH_SHORT).show()
+
+                scheduleWeeklyNotification(applicationContext)
+                scheduleDailyNotification(applicationContext)
             } else {
                 requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         } else {
             Toast.makeText(this, "Notification permission not required for this Android version", Toast.LENGTH_SHORT).show()
+
+            scheduleWeeklyNotification(applicationContext)
+            scheduleDailyNotification(applicationContext)
         }
     }
+
 }

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationHandler.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationHandler.kt
@@ -35,4 +35,27 @@ class NotificationHandler(private val context: Context) {
 
         notificationManager.notify(Random.nextInt(), notification)
     }
+
+    fun showDailyQuestionNotification() {
+        val channelId = context.getString(R.string.daily_question_channel_id)
+
+        val name = context.getString(R.string.daily_question_channel_name)
+        val descriptionText = context.getString(R.string.daily_question_channel_description)
+        val importance = NotificationManager.IMPORTANCE_HIGH
+        val channel = NotificationChannel(channelId, name, importance).apply {
+            description = descriptionText
+        }
+        notificationManager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setContentTitle(context.getString(R.string.daily_question_notification_title))
+            .setContentText(context.getString(R.string.daily_question_notification_text))
+            .setSmallIcon(R.drawable.notification)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(Random.nextInt(), notification)
+    }
+
 }

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationWorker.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/NotificationWorker.kt
@@ -10,9 +10,22 @@ class NotificationWorker(
     workerParams: WorkerParameters,
 ) :  CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result {
-        Log.d("NotificationWorker", "Showing notification")
+
+        val type = inputData.getString("type")
+
         val notificationHandler = NotificationHandler(applicationContext)
-        notificationHandler.showWordOfWeekNotification()
+
+        when (type) {
+            "daily" -> {
+                notificationHandler.showDailyQuestionNotification()
+            }
+            "weekly" -> {
+                notificationHandler.showWordOfWeekNotification()
+            }
+            else -> Log.w("NotificationWorker", "Unknown notification type")
+        }
+
         return Result.success()
     }
+
 }

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleDailyNotification.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleDailyNotification.kt
@@ -1,0 +1,40 @@
+package com.example.zadumite_frontend.utils.notifications
+import android.content.Context
+import androidx.work.WorkManager
+import androidx.work.Data
+import androidx.work.ExistingPeriodicWorkPolicy
+import java.util.concurrent.TimeUnit
+
+import androidx.work.PeriodicWorkRequestBuilder
+import java.util.Calendar
+
+fun scheduleDailyNotification(context: Context) {
+    val inputData = Data.Builder()
+        .putString("type", "daily")
+        .build()
+
+    val calendar = Calendar.getInstance().apply {
+        timeInMillis = System.currentTimeMillis()
+        set(Calendar.HOUR_OF_DAY, 10)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+
+        if (before(Calendar.getInstance())) {
+            add(Calendar.DAY_OF_YEAR, 1)
+        }
+    }
+
+    val initialDelay = calendar.timeInMillis - System.currentTimeMillis()
+
+    val dailyWorkRequest = PeriodicWorkRequestBuilder<NotificationWorker>(1, TimeUnit.DAYS)
+        .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
+        .setInputData(inputData)
+        .build()
+
+    WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+        "DailyQuestionNotification",
+        ExistingPeriodicWorkPolicy.UPDATE,
+        dailyWorkRequest
+    )
+}

--- a/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleWeeklyNotification.kt
+++ b/app/src/main/java/com/example/zadumite_frontend/utils/notifications/scheduleWeeklyNotification.kt
@@ -15,6 +15,7 @@ fun scheduleWeeklyNotification(context: Context) {
     val testMode = true
 
     val inputData = Data.Builder()
+        .putString("type", "weekly")
         .putString("title", "Дума на седмицата")
         .putString("message", "Узнай думата на седмицата!")
         .build()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,9 @@
     <string name="notification_channel_id">new_word</string>
     <string name="notification_channel_name">Дума на седмицата</string>
     <string name="notification_channel_description">Известия за думата на седмицата</string>
+    <string name="daily_question_channel_id">daily_question</string>
+    <string name="daily_question_channel_name">Дневен въпрос</string>
+    <string name="daily_question_channel_description">Известия за дневния въпрос</string>
+    <string name="daily_question_notification_title">Дневен въпрос</string>
+    <string name="daily_question_notification_text">Готов ли си за нов въпрос днес?</string>
 </resources>


### PR DESCRIPTION
This PR implements a new daily notification system to remind users about the daily question at 10 a.m. The notification uses WorkManager to schedule periodic background tasks.
- Added daily question notification that triggers every day at 10:00 a.m.
- Used WorkManager's `PeriodicWorkRequest` to handle scheduling.
- Reused the existing `NotificationWorker` with a new `type` parameter (`"daily"` or `"weekly"`).
- Ensured that the notification is only scheduled after the user logs in and grants permission.